### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -255,7 +255,7 @@ fn main() -> std::io::Result<()> {
     world[halfway_idx] = 1;
 
     display_rule_array(rule_array);
-    println!("   In binary: {:08.b}", rule);
+    println!("   In binary: {:08b}", rule);
 
     let mut my_output: String = "".to_string();
     


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.